### PR TITLE
fix: set alpine version to 3.19 to allow aws-cli installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.19
 
 RUN apk --update --no-cache add git aws-cli
 


### PR DESCRIPTION
fixes: #6 